### PR TITLE
Refactor(http): Separated http layer for each service route

### DIFF
--- a/internal/lib/app/app.go
+++ b/internal/lib/app/app.go
@@ -51,7 +51,7 @@ func (a *App) Execute(command string) error {
 		err = core.CreateService()
 	case "http":
 		fmt.Printf("Building %s... \n", command)
-		err = a.CreateHttpAdapter()
+		err = core.CreateHttpAdapter()
 	case "storage":
 		fmt.Printf("Building %s... \n", command)
 		err = a.CreateStorageAdapter()

--- a/internal/lib/app/storage.go
+++ b/internal/lib/app/storage.go
@@ -3,6 +3,7 @@ package app
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
 	"github.com/x86-Yantras/code-gen/internal/adapters/templates"
@@ -208,6 +209,23 @@ func (app *App) BuildStorageIndex(storageImports map[string]map[string]bool) err
 			Overwrite: true,
 		})
 
+		return err
+	}
+
+	return nil
+}
+
+// Temporary for not breaking storage generation
+func (app *App) BuildAdapterDir(serviceName, adapterType string) error {
+	// create adapters dir
+	adapterDir := fmt.Sprintf(app.Config.AdapterDir, serviceName)
+
+	if err := app.Templater.CreateDir(adapterDir); err != nil {
+		return err
+	}
+
+	adapterPath := fmt.Sprintf("%s/%s", adapterDir, adapterType)
+	if err := app.Templater.CreateDir(strings.ToLower(adapterPath)); err != nil {
 		return err
 	}
 

--- a/templates/node/src/services/servicename/adapters/api/http/handler.js.tmpl
+++ b/templates/node/src/services/servicename/adapters/api/http/handler.js.tmpl
@@ -1,7 +1,7 @@
 const createContext = require("../../../../../lib/context/context");
 const logger = require("../../../../../lib/logger/logger")();
-const {{.ServiceName}}Svc = require("../../../service/{{.ServiceName}}")
-const { {{.ServiceName}}Payload } = require("../../../service/types")
+const {{.OperationID}}Svc = require("../../../service/{{.OperationID}}")
+const { {{.OperationID}}Payload } = require("../../../service/types")
 
 // {{.HandlerName}}...
 const {{.HandlerName}} = async (req, res) => {
@@ -13,7 +13,7 @@ const {{.HandlerName}} = async (req, res) => {
         ...req.query 
       }
 
-      const resp = await {{.ServiceName}}Svc(context, {{.ServiceName}}Payload(payload))
+      const resp = await {{.OperationID}}Svc(context, {{.OperationID}}Payload(payload))
       return res.status({{.HttpStatusCode}}).json(svcToResponse(resp))
   } catch (error) {
       logger.error(error)

--- a/templates/node/src/services/servicename/adapters/api/http/handler.spec.js.tmpl
+++ b/templates/node/src/services/servicename/adapters/api/http/handler.spec.js.tmpl
@@ -3,28 +3,28 @@ const supertest = require("supertest");
 const routes = require("./routes");
 
 const server = require("../../../../../lib/test/server")(routes);
-const {{.ServiceName}}Svc = require("../../../service/{{.ServiceName}}");
-const { {{.ServiceName}}PayloadSchema } = require("../../../service/types");
+const {{.OperationID}}Svc = require("../../../service/{{.OperationID}}");
+const { {{.OperationID}}PayloadSchema } = require("../../../service/types");
 
 const fake = require("../../../../../lib/test/faker");
 
-jest.mock("../../../service/{{.ServiceName}}", () => jest.fn());
+jest.mock("../../../service/{{.OperationID}}", () => jest.fn());
 
 const request = supertest(server);
 
 describe("{{.HandlerName}} test", () => {
   it("should handle 500 error", async () => {
-    {{.ServiceName}}Svc.mockRejectedValue("internal server error");
+    {{.OperationID}}Svc.mockRejectedValue("internal server error");
 
-    const payload = fake({{.ServiceName}}PayloadSchema);
+    const payload = fake({{.OperationID}}PayloadSchema);
     const res = await request.{{.Method}}("{{.Path}}").send(payload);
 
     expect(res.statusCode).toEqual(500);
   });
 
   it("should return success with {{.HttpStatusCode}}", async () => {
-    {{.ServiceName}}Svc.mockResolvedValue({ test: true });
-    const payload = fake({{.ServiceName}}PayloadSchema);
+    {{.OperationID}}Svc.mockResolvedValue({ test: true });
+    const payload = fake({{.OperationID}}PayloadSchema);
     const res = await request.{{.Method}}("{{.Path}}").send(payload);
 
     expect(res.statusCode).toEqual({{.HttpStatusCode}});
@@ -34,12 +34,12 @@ describe("{{.HandlerName}} test", () => {
   });
 
    it("should handle service 400 error", async () => {
-    {{.ServiceName}}Svc.mockRejectedValue({
+    {{.OperationID}}Svc.mockRejectedValue({
       httpStatusCode: 400,
       name: "ValidationError",
     });
 
-    {{if (ne .Method "get" )}}const payload = fake({{.ServiceName}}PayloadSchema);{{end}}
+    {{if (ne .Method "get" )}}const payload = fake({{.OperationID}}PayloadSchema);{{end}}
     {{- if (eq .Method "get")}}
     const res = await request.{{.Method}}("{{.Path}}");
     {{- else}}


### PR DESCRIPTION
- Moves http layer to core.
- Make http generation functionality more granular
- No changes from file generation perspective